### PR TITLE
[2371] Use cursor.lastrowid instead of SELECT query for SQLite/MySQL.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="twistar",
-    version="1.1-chevah4",
+    version="1.1-c5",
     description="An implementation of the Active Record pattern for Twisted",
     author="Brian Muller",
     author_email="bamuller@gmail.com",

--- a/twistar/dbconfig/mysql.py
+++ b/twistar/dbconfig/mysql.py
@@ -11,7 +11,13 @@ class MySQLDBConfig(InteractionBase):
         if len(vals) > 0:
             return "(" + ",".join(["%s" for _ in vals.items()]) + ")"            
         return "VALUES ()"
-    
+
+    def getLastInsertID(self, txn):
+        """
+        Return last inserted row's ID or None.
+        """
+        return txn.lastrowid
+
 
 class ReconnectingMySQLConnectionPool(adbapi.ConnectionPool):
     """

--- a/twistar/dbconfig/sqlite.py
+++ b/twistar/dbconfig/sqlite.py
@@ -11,10 +11,10 @@ class SQLiteDBConfig(InteractionBase):
 
 
     def getLastInsertID(self, txn):
-        q = "SELECT last_insert_rowid()"
-        self.executeTxn(txn, q)
-        result = txn.fetchall()
-        return result[0][0]
+        """
+        Return last inserted row's ID or None.
+        """
+        return txn.lastrowid
                             
 
     def updateArgsToString(self, args):


### PR DESCRIPTION
## Problem

Both `SQLite` and `MySQL` Python DB-APIs provide last insert row ID value using a cursor property thus making a second query not required.
## Changes

Instead of using a SELECT statement to retrieve the last inserted row ID both SQLite/MySQL configurations were changed to use `cursor.lastrowid`.
## How to test

reviewers @adiroiban 

Please check that the code changes make sense. Thanks!

PS: I've already prepared two system tests for server (SQLite/MySQL) to check that the saved entry ID's is updated accordingly.
